### PR TITLE
Bugfix/ucclient-4622

### DIFF
--- a/src/UA.ts
+++ b/src/UA.ts
@@ -337,7 +337,9 @@ export class UA extends EventEmitter {
         if (context.autoSendAnInitialProvisionalResponse) {
           context.progress();
         }
-        this.emit("invite", context);
+        if (!this.isBusyCauseOutgoingCallInProgress) {
+          this.emit("invite", context);
+        }
       },
       onMessage: (incomingMessageRequest: IncomingMessageRequest): void => {
         // Ported - handling of out of dialog MESSAGE.

--- a/src/UA.ts
+++ b/src/UA.ts
@@ -156,6 +156,12 @@ export class UA extends EventEmitter {
   public data: any;
   public logger: Logger;
 
+  /**
+   * isBusyCauseOutgoingCallInProgress parameter added to adjust logic for incoming call during
+   * outgoing call (remove "180 Ringing" status and send "486 Busy Here" exactly after "100 Trying" status)
+   */
+  public isBusyCauseOutgoingCallInProgress: boolean = false;
+
   public userAgentCore: UserAgentCore;
 
   private log: LoggerFactory;


### PR DESCRIPTION
In case the outgoing call is in progress then reject any incoming call with "486 Busy Here" status exactly after "100 Trying" status, so the "180 Ringing status" is removed (for backend purposes) 